### PR TITLE
Update nvidia-xorg.conf

### DIFF
--- a/nvidia-xorg.conf
+++ b/nvidia-xorg.conf
@@ -1,5 +1,5 @@
 Section "Files"
-  ModulePath "/usr/lib/nvidia"
+  ModulePath "/usr/lib64/nvidia"
   ModulePath "/usr/lib32/nvidia"
   ModulePath "/usr/lib32/nvidia/xorg/modules"
   ModulePath "/usr/lib32/xorg/modules"


### PR DESCRIPTION
### Descirption

This is the thing I had to do to make nvidia-xrun work on my Fedora 28 box. Afterwards, I had to install the nvidia-libs:i686 so I could use Steam! 

I am using openbox for my nvidia environment and it works well!